### PR TITLE
Added timeout error

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,6 @@
+const got = require('got');
+
+module.exports = {
+    TIMEOUT_ERR: got.TimeoutError,
+
+};

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,6 +1,6 @@
 const got = require('got');
 
 module.exports = {
-    TIMEOUT_ERR: got.TimeoutError,
+    TimeoutError: got.TimeoutError,
 
 };


### PR DESCRIPTION
The main idea is to expose the got errors within the `httpRequest` package, so they can be used in other packages as well. The motivation was because of the `CheerioCrawler`, which needs to recognize the timeout error from the others. In order to preserve the API the errors can be required as follows:

```
const ERRORS = require(@apify/http-request/errors) 


```