### PR TITLE
Fix host header problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@apify/http-request",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "description": "Wrapper of got package used across Apify",
     "main": "src/index.js",
     "repository": "https://github.com/apifytech/http-request",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     },
     "dependencies": {
         "apify-shared": "^0.2.11",
-        "got": "^9.6.0",
+        "got": "^11.1.4",
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "^5.0.0"
     }

--- a/src/create_case_sensitive_hook.js
+++ b/src/create_case_sensitive_hook.js
@@ -1,14 +1,44 @@
 /**
  * Overrides got lower-cased headers to case sensitive ones.
- * @param requestOptions {Object} - Got options
+ * @param ourOptions {Object} - Got options
  */
-module.exports = (requestOptions) => {
-    return ({ headers: finalHeaders }) => {
-        Object.entries(requestOptions.headers).forEach(([key, value]) => {
-            if (finalHeaders[key.toLowerCase()]) {
-                delete finalHeaders[key.toLowerCase()];
-                finalHeaders[key] = value;
+module.exports = (ourOptions) => {
+    return (gotOptions) => {
+        Object.entries(ourOptions.headers).forEach(([key, value]) => {
+            if (gotOptions.headers[key.toLowerCase()]) {
+                delete gotOptions.headers[key.toLowerCase()];
+                gotOptions.headers[key] = value;
             }
         });
+        // Do not allow Host header override, because it breaks the internet.
+        // If someone needs it, they can use a different client.
+        delete gotOptions.headers.Host;
+        gotOptions.headers = {
+            Host: createNodeLikeHostHeader(gotOptions.url),
+            ...gotOptions.headers,
+        };
     };
 };
+
+/**
+ * @param {URL} url
+ * @returns {string}
+ */
+function createNodeLikeHostHeader(url) {
+    let hostHeader = url.hostname || url.host || 'localhost';
+
+    // For the Host header, ensure that IPv6 addresses are enclosed
+    // in square brackets, as defined by URI formatting
+    // https://tools.ietf.org/html/rfc3986#section-3.2.2
+    const posColon = hostHeader.indexOf(':');
+    if (posColon !== -1
+        && hostHeader.includes(':', posColon + 1)
+        && hostHeader.charCodeAt(0) !== 91/* '[' */) {
+        hostHeader = `[${hostHeader}]`;
+    }
+
+    if (url.port) {
+        hostHeader += `:${url.port}`;
+    }
+    return hostHeader;
+}

--- a/test/http_request.test.js
+++ b/test/http_request.test.js
@@ -258,11 +258,11 @@ describe('httpRequest', () => {
 
 
     test('passes response to abortFunction', async () => {
-        let constructorName;
+        let response;
         const data = {
             url: `http://${HOST}:${port}/gzip`,
-            abortFunction: (response) => {
-                constructorName = response.constructor.name;
+            abortFunction: (res) => {
+                response = res;
                 return false;
             },
 
@@ -270,27 +270,25 @@ describe('httpRequest', () => {
 
         await httpRequest(data);
 
-        expect(constructorName).toBe('Transform');
+        expect(response.constructor.name).toBe('IncomingMessage');
+        expect(response.body).toBe(CONTENT);
     });
 
-    test(
-        'it does not aborts request when aborts function returns false',
-        async () => {
-            let aborted = false;
-            const data = {
-                url: `http://${HOST}:${port}/gzip`,
-                abortFunction: (response) => {
-                    response.on('aborted', () => {
-                        aborted = true;
-                    });
-                    return false;
-                },
+    test('it does not aborts request when aborts function returns false', async () => {
+        let aborted = false;
+        const data = {
+            url: `http://${HOST}:${port}/gzip`,
+            abortFunction: (response) => {
+                response.on('aborted', () => {
+                    aborted = true;
+                });
+                return false;
+            },
 
-            };
-            await httpRequest(data);
-            expect(aborted).toBe(false);
-        },
-    );
+        };
+        await httpRequest(data);
+        expect(aborted).toBe(false);
+    });
 
     test('it aborts request', async () => {
         const data = {
@@ -346,59 +344,50 @@ describe('httpRequest', () => {
         expect(response.body).toEqual(CONTENT);
     });
 
-    test(
-        'it does not throw error for 400+ error codes when throwOnHttpError is false',
-        async () => {
-            const options = {
-                url: `http://${HOST}:${port}/500`,
-            };
-            let error;
-            try {
-                await httpRequest(options);
-            } catch (e) {
-                error = e;
-            }
+    test('it does not throw error for 400+ error codes when throwOnHttpError is false', async () => {
+        const options = {
+            url: `http://${HOST}:${port}/500`,
+        };
+        let error;
+        try {
+            await httpRequest(options);
+        } catch (e) {
+            error = e;
+        }
                 expect(error).toBeUndefined(); // eslint-disable-line
-        },
-    );
+    });
 
-    test(
-        'it does throw error for 400+ error codes when throwOnHttpErrors is true',
-        async () => {
-            const options = {
-                url: `http://${HOST}:${port}/500`,
-                throwOnHttpErrors: true,
+    test('it does throw error for 400+ error codes when throwOnHttpErrors is true', async () => {
+        const options = {
+            url: `http://${HOST}:${port}/500`,
+            throwOnHttpErrors: true,
 
-            };
-            let error;
+        };
+        let error;
 
-            try {
-                await httpRequest(options);
-            } catch (e) {
-                error = e;
-            }
+        try {
+            await httpRequest(options);
+        } catch (e) {
+            error = e;
+        }
 
             expect(error.message).toBeDefined(); // eslint-disable-line
-        },
-    );
+    });
 
-    test(
-        'it throws error when the body cannot be parsed and the code is 500 when throwOnHttpErrors is true',
-        async () => {
-            const options = {
-                url: `http://${HOST}:${port}/500/invalidBody`,
-                throwOnHttpErrors: true,
+    test('it throws error when the body cannot be parsed and the code is 500 when throwOnHttpErrors is true', async () => {
+        const options = {
+            url: `http://${HOST}:${port}/500/invalidBody`,
+            throwOnHttpErrors: true,
 
-            };
-            let error;
-            try {
-                await httpRequest(options);
-            } catch (e) {
-                error = e;
-            }
+        };
+        let error;
+        try {
+            await httpRequest(options);
+        } catch (e) {
+            error = e;
+        }
                 expect(error.message).toBeDefined(); // eslint-disable-line
-        },
-    );
+    });
 
     test('it throws error when the body cannot be parsed', async () => {
         const options = {
@@ -425,18 +414,17 @@ describe('httpRequest', () => {
 
         // check for response properties.
         expect(stream.statusCode).toBe(200);
-        expect(stream.headers).toBeDefined(); //eslint-disable-line
-        expect(stream.complete).toBeDefined(); //eslint-disable-line
+        expect(stream.headers).toBeDefined();
+        expect(stream.complete).toBeDefined();
         expect(stream.httpVersion).toBe('1.1');
-        expect(stream.rawHeaders).toBeDefined(); //eslint-disable-line
-        expect(stream.rawTrailers).toBeDefined(); //eslint-disable-line
-        expect(stream.socket).toBeDefined(); //eslint-disable-line
+        expect(stream.rawHeaders).toBeDefined();
+        expect(stream.rawTrailers).toBeDefined();
+        expect(stream.socket).toBeDefined();
         expect(stream.statusMessage).toBe('OK');
-        expect(stream.trailers).toBeDefined(); //eslint-disable-line
-        expect(stream.url).toBeDefined(); //eslint-disable-line
-        expect(stream.request).toBeDefined(); //eslint-disable-line
-        expect(stream.request.gotOptions).toBeDefined(); //eslint-disable-line
-        expect(stream.request.gotOptions).toBeDefined(); //eslint-disable-line
+        expect(stream.trailers).toBeDefined();
+        expect(stream.url).toBeDefined();
+        expect(stream.request).toBeDefined();
+        expect(stream.request.options).toBeDefined();
 
         const content = await readStreamToString(stream);
         expect(content).toEqual(CONTENT);


### PR DESCRIPTION
Update `got` and fix redirect loops by improving the handling of host headers.

I'm bumping major version, because there were a lot of incompatible changes in `got` between 9 and 11 and even though `http-request` API has not changed, people may have been using `got` options directly and I don't want to break their projects.